### PR TITLE
Improve PDF export and handle garbled SEO text

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ This repository contains a Streamlit application for combined SEO and AIO (AI se
    ```bash
    streamlit run seo_aio_streamlit.py
    ```
+4. Run a quick syntax check (optional but recommended):
+   ```bash
+   python -m py_compile $(git ls-files '*.py')
+   ```
 
 ## Modules
 


### PR DESCRIPTION
## Summary
- add `detect_mojibake` helper
- flag garbled SEO title and description in GUI
- include SEO analysis section in PDF with page break
- detect and mark garbled text in PDF output
- document syntax check step

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684b9c57a4e08333a9d96fad22df2c34