### PR TITLE
Phase5: improve report design and Japanese labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,9 @@ The code has been modularized:
 - `core/visualization.py` – helper functions for charts.
 
 The main `seo_aio_streamlit.py` script imports these modules.
+
+## Features
+
+- Japanese-labeled SEO score graphs for better clarity.
+- Enhanced PDF reports with actionable insights and modern styling.
+- Added conclusion and next-steps section in PDF reports.

--- a/core/constants.py
+++ b/core/constants.py
@@ -48,3 +48,14 @@ AIO_SCORE_MAP_JP_LOWER = {
 }
 
 AIO_SCORE_MAP_JP = {**AIO_SCORE_MAP_JP_UPPER, **AIO_SCORE_MAP_JP_LOWER}
+
+# SEOスコア項目ラベル（日本語）
+SEO_SCORE_LABELS = {
+    "title_score": "タイトル",
+    "meta_description_score": "メタディスクリプション",
+    "headings_score": "見出し構造",
+    "content_score": "コンテンツ",
+    "links_score": "リンク",
+    "images_score": "画像",
+    "technical_score": "技術要素",
+}


### PR DESCRIPTION
## Summary
- add bullet conclusion and next steps section in PDF
- explain SEO metrics' impact in the report
- fine-tune SEO chart hover text and layout
- document report improvements

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684ba31282408333ab7f0fec7971fb58