### PR TITLE
Fix AIO score normalization

### DIFF
--- a/tests/test_scaling.py
+++ b/tests/test_scaling.py
@@ -1,0 +1,24 @@
+import unittest
+try:
+    from seo_aio_streamlit import SEOAIOAnalyzer
+except Exception:
+    SEOAIOAnalyzer = None
+
+@unittest.skipUnless(SEOAIOAnalyzer, "main module not available")
+class TestScaling(unittest.TestCase):
+    def setUp(self):
+        # No API initialization for this test
+        analyzer = object.__new__(SEOAIOAnalyzer)
+        self.scale = analyzer._scale_to_100
+
+    def test_scale_small(self):
+        self.assertEqual(self.scale(7), 70)
+
+    def test_scale_normal(self):
+        self.assertEqual(self.scale(85), 85)
+
+    def test_scale_over(self):
+        self.assertEqual(self.scale(120), 100)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- normalize AIO total and category scores to 0-100 scale
- apply scale when integrating results
- add helper `_scale_to_100`
- test new scaling helper

## Testing
- `python -m unittest discover tests`

------
https://chatgpt.com/codex/tasks/task_e_684c2b8bae688333bff44afb3890b094