### PR TITLE
Apply design tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ The main `seo_aio_streamlit.py` script imports these modules.
 
 ## Design Guidelines
 
-The interface uses an Intel-inspired palette:
+- The interface uses an Intel-inspired palette:
 
-- **Primary:** `#00C7FD` (Intel Blue)
-- **Secondary:** `#0068B5`
+  - **Primary:** `#00C7FD` (Intel Blue)
+  - **Secondary:** unified with the primary color for clarity
 - Icons rely on simple geometric pictograms without illustrations.

--- a/core/constants.py
+++ b/core/constants.py
@@ -7,8 +7,8 @@ APP_NAME = "SEO・AIO統合分析ツール"
 # インテル風カラースキーム
 COLOR_PALETTE = {
     "primary": "#00C7FD",        # Intel Blue
-    "secondary": "#0068B5",      # Intel Dark Blue
-    "accent": "#0068B5",
+    "secondary": "#00C7FD",      # unify blue shades
+    "accent": "#00C7FD",
     "background": "#FFFFFF",
     "surface": "#F5F7FA",
     "text_primary": "#333333",
@@ -18,11 +18,11 @@ COLOR_PALETTE = {
     "error": "#F44336",
     "info": "#2196F3",
     "gold": "#FF8C00",
-    "dark_blue": "#0068B5",
+    "dark_blue": "#00C7FD",
 }
 
 # フォント設定
-FONT_STACK = "'Inter', 'Segoe UI', 'Roboto', 'Helvetica Neue', sans-serif"
+FONT_STACK = "'Noto Sans JP', 'Meiryo', 'Hiragino Kaku Gothic ProN', 'Inter', 'Segoe UI', 'Roboto', 'Helvetica Neue', sans-serif"
 
 # AIOスコアマッピング
 AIO_SCORE_MAP_JP_UPPER = {

--- a/core/ui_components.py
+++ b/core/ui_components.py
@@ -24,10 +24,10 @@ def load_global_styles() -> None:
             border: none;
             border-radius: 4px;
             padding: 0.4rem 1rem;
-            font-weight: 600;
+            font-weight: 400;
         }}
         .primary-button > button:hover {{
-            background-color: {COLOR_PALETTE['secondary']};
+            background-color: {COLOR_PALETTE['primary']};
         }}
         .input-block {{
             background-color: #f0f2f6;


### PR DESCRIPTION
## Summary
- unify secondary colors with the primary palette
- update font stack to include common Japanese fonts
- lighten button typography
- note unified color usage in README

## Testing
- `python -m unittest discover tests`

------
https://chatgpt.com/codex/tasks/task_e_684c49a1e5688333ac79790f71eecfa5