### PR TITLE
Improve UI consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,5 @@ The main `seo_aio_streamlit.py` script imports these modules.
   - **Primary:** `#00C7FD` (Intel Blue)
   - **Secondary:** unified with the primary color for clarity
 - Icons rely on simple geometric pictograms without illustrations.
+- Typography follows `'Noto Sans JP', 'Meiryo', 'Hiragino Kaku Gothic ProN', 'Inter'` with light weights (300–400).
+- Sections are separated by thin dividers for a clean layout.

--- a/core/constants.py
+++ b/core/constants.py
@@ -19,6 +19,7 @@ COLOR_PALETTE = {
     "info": "#2196F3",
     "gold": "#FF8C00",
     "dark_blue": "#00C7FD",
+    "divider": "#E0E0E0",
 }
 
 # フォント設定

--- a/core/ui_components.py
+++ b/core/ui_components.py
@@ -18,6 +18,9 @@ def load_global_styles() -> None:
             font-size: 16px;
             font-weight: 300;
         }}
+        h1, h2, h3, h4 {{
+            font-weight: 400;
+        }}
         .primary-button > button {{
             background-color: {COLOR_PALETTE['primary']};
             color: white;
@@ -44,7 +47,7 @@ def load_global_styles() -> None:
         .function-section {{
             background-color: {COLOR_PALETTE['surface']};
             padding: 1rem;
-            border: 1px solid {COLOR_PALETTE['secondary']};
+            border: 1px solid {COLOR_PALETTE['divider']};
             border-radius: 8px;
             margin-bottom: 1rem;
         }}

--- a/seo_aio_streamlit.py
+++ b/seo_aio_streamlit.py
@@ -101,7 +101,22 @@ try:
         if not found_font_mac:
             DEFAULT_PDF_FONT = 'Helvetica'
     else:
-        DEFAULT_PDF_FONT = 'Helvetica'
+        font_paths_noto = [
+            '/usr/share/fonts/truetype/noto/NotoSansCJK-Regular.ttc',
+            '/usr/share/fonts/truetype/noto/NotoSansCJKjp-Regular.otf',
+        ]
+        found_font_linux = False
+        for p in font_paths_noto:
+            if os.path.exists(p):
+                try:
+                    pdfmetrics.registerFont(TTFont('NotoSansJP', p))
+                    DEFAULT_PDF_FONT = 'NotoSansJP'
+                    found_font_linux = True
+                    break
+                except Exception as e_font_linux:
+                    print(f"Notoフォント登録試行エラー ({p}): {e_font_linux}")
+        if not found_font_linux:
+            DEFAULT_PDF_FONT = 'Helvetica'
 except Exception as font_error:
     print(f"日本語フォントの登録に失敗しました: {font_error}")
     DEFAULT_PDF_FONT = 'Helvetica'
@@ -160,7 +175,7 @@ def section_break(story, width) -> None:
         colWidths=[width],
         style=TableStyle(
             [
-                ("LINEBELOW", (0, 0), (-1, -1), 1, colors.HexColor(COLOR_PALETTE["secondary"]))
+                ("LINEBELOW", (0, 0), (-1, -1), 0.5, colors.HexColor(COLOR_PALETTE["divider"]))
             ]
         ),
     )
@@ -883,9 +898,12 @@ JSON以外のテキストや説明は一切含めないでください。
             return str(value) if value is not None else default
 
         doc = SimpleDocTemplate(
-            output_path, pagesize=A4,
-            rightMargin=1.5*cm, leftMargin=1.5*cm,
-            topMargin=1.5*cm, bottomMargin=1.5*cm
+            output_path,
+            pagesize=A4,
+            rightMargin=2*cm,
+            leftMargin=2*cm,
+            topMargin=2*cm,
+            bottomMargin=2*cm,
         )
 
 
@@ -1223,11 +1241,11 @@ def set_custom_css():
         <style>
         .css-1d391kg {{
             background-color: {COLOR_PALETTE['surface']};
-            border-right: 1px solid {COLOR_PALETTE['secondary']};
+            border-right: 1px solid {COLOR_PALETTE['divider']};
         }}
         [data-testid='metric-container'] {{
             background-color: {COLOR_PALETTE['surface']};
-            border: 1px solid {COLOR_PALETTE['secondary']};
+            border: 1px solid {COLOR_PALETTE['divider']};
             padding: 1rem;
             border-radius: 8px;
             box-shadow: 0 2px 4px rgba(0,0,0,0.05);


### PR DESCRIPTION
## Summary
- add divider color to palette
- adjust fonts and styles for thin dividers and lighter layout
- update PDF margins and try Noto Sans on Linux
- document new style guidelines

## Testing
- `python -m unittest discover tests`

------
https://chatgpt.com/codex/tasks/task_e_684cd039a51c8333b7fef900671d1d73