### PR TITLE
Implement industry personalization scoring

### DIFF
--- a/core/aio_scorer.py
+++ b/core/aio_scorer.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+"""AIO scoring helpers."""
+from typing import Dict, List, Tuple
+
+
+def calculate_personalization_score(text: str, industry: str, industry_contents_map: Dict[str, Dict]) -> Tuple[float, List[str]]:
+    """Return coverage score and missing recommended keywords."""
+    if not text or industry not in industry_contents_map:
+        return 0.0, []
+    keywords: List[str] = industry_contents_map[industry].get('keywords', [])
+    if not keywords:
+        return 0.0, []
+    text_lower = text.lower()
+    missing: List[str] = []
+    matched = 0
+    for kw in keywords:
+        if kw.lower() in text_lower:
+            matched += 1
+        else:
+            missing.append(kw)
+    score = (matched / len(keywords)) * 100 if keywords else 0.0
+    return score, missing

--- a/core/industry_detector.py
+++ b/core/industry_detector.py
@@ -3,6 +3,33 @@
 from dataclasses import dataclass
 from typing import List
 
+# Recommended contents per industry for personalization analysis
+INDUSTRY_CONTENTS = {
+    "restaurant": {
+        "keywords": ["メニュー", "コース", "予約", "アクセス", "地図", "テイクアウト", "デリバリー"],
+        "display_name": "飲食店",
+    },
+    "construction": {
+        "keywords": ["施工事例", "お客様の声", "技術紹介", "安全管理", "会社概要", "見積もり"],
+        "display_name": "建設業",
+    },
+    "clinic": {
+        "keywords": ["診療案内", "医師紹介", "アクセス", "予約", "診療時間", "初診"],
+        "display_name": "クリニック",
+    },
+}
+
+
+def detect_industry(text: str) -> str:
+    """Detect industry key based on keyword matching."""
+    if not text:
+        return "unknown"
+    lowered = text.lower()
+    for key, info in INDUSTRY_CONTENTS.items():
+        if any(keyword.lower() in lowered for keyword in info.get("keywords", [])):
+            return key
+    return "unknown"
+
 @dataclass
 class IndustryAnalysis:
     """業界分析結果"""

--- a/seo_aio_streamlit.py
+++ b/seo_aio_streamlit.py
@@ -153,7 +153,13 @@ from core.constants import (
     SEO_SCORE_LABELS,
 )
 from core.ui_components import load_global_styles, primary_button, text_input
-from core.industry_detector import IndustryDetector, IndustryAnalysis
+from core.industry_detector import (
+    IndustryDetector,
+    IndustryAnalysis,
+    INDUSTRY_CONTENTS,
+    detect_industry,
+)
+from core.aio_scorer import calculate_personalization_score
 from core.visualization import create_aio_score_chart_vertical
 from core.text_utils import detect_mojibake
 
@@ -182,6 +188,14 @@ def section_break(story, width) -> None:
     story.append(Spacer(1, 2 * mm))
     story.append(line)
     story.append(Spacer(1, 2 * mm))
+
+
+def calculate_aio_score(text: str):
+    """Simple AIO scoring with industry personalization."""
+    industry = detect_industry(text)
+    score, missing = calculate_personalization_score(text, industry, INDUSTRY_CONTENTS)
+    scores = {"業種適合性": score}
+    return score, scores, industry, missing
 
 
 

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -1,5 +1,5 @@
 import unittest
-from core.industry_detector import IndustryDetector
+from core.industry_detector import IndustryDetector, detect_industry
 
 class TestIndustryDetector(unittest.TestCase):
     def setUp(self):
@@ -12,6 +12,11 @@ class TestIndustryDetector(unittest.TestCase):
         self.assertEqual(result.primary_industry, "IT・テクノロジー")
         self.assertGreater(result.confidence_score, 0)
         self.assertIn("クラウド", result.industry_keywords)
+
+    def test_detect_industry_simple(self):
+        text = "予約やテイクアウトに対応した当店のメニューをご覧ください"
+        industry = detect_industry(text)
+        self.assertEqual(industry, "restaurant")
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_personalization.py
+++ b/tests/test_personalization.py
@@ -1,0 +1,15 @@
+import unittest
+from core.aio_scorer import calculate_personalization_score
+from core.industry_detector import INDUSTRY_CONTENTS
+
+
+class TestPersonalizationScore(unittest.TestCase):
+    def test_personalization_score(self):
+        text = "当店のメニューをご確認いただき、予約も簡単にできます。アクセスも便利です。"
+        score, missing = calculate_personalization_score(text, 'restaurant', INDUSTRY_CONTENTS)
+        self.assertGreater(score, 40)
+        self.assertIn('地図', missing)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `INDUSTRY_CONTENTS` and `detect_industry` utilities
- provide `calculate_personalization_score` helper
- expose new function `calculate_aio_score`
- test personalization scoring and industry detection

## Testing
- `python -m unittest discover tests`

------
https://chatgpt.com/codex/tasks/task_e_688960abd4888333924f71b0ef816559