### PR TITLE
Fix personalization text

### DIFF
--- a/core/constants.py
+++ b/core/constants.py
@@ -39,7 +39,7 @@ AIO_SCORE_MAP_JP_UPPER = {
 
 AIO_SCORE_MAP_JP_LOWER = {
     "search_intent": "検索意図マッチング",
-    "personalization": "ーソナライズ可能性",
+    "personalization": "パーソナライズ可能性",
     "uniqueness": "情報の独自性",
     "completeness": "コンテンツの完全性",
     "readability": "読みやすさスコア",


### PR DESCRIPTION
## Summary
- correct Japanese label for personalization in AIO score map

## Testing
- `python -m unittest discover tests`

------
https://chatgpt.com/codex/tasks/task_e_688976df509c833395770c3b946651b6