### PR TITLE
Add industry advice generation

### DIFF
--- a/core/advice_utils.py
+++ b/core/advice_utils.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+"""Helper for generating industry-specific advice."""
+from typing import List
+from .industry_detector import INDUSTRY_CONTENTS
+
+
+def generate_actionable_advice(missing_keywords: List[str], industry: str) -> str:
+    """Return advice string based on missing keywords and industry.
+
+    If industry is known, use its display name. Otherwise provide generic guidance.
+    """
+    if not missing_keywords:
+        return "特に不足している重要キーワードは見当たりません。"
+
+    info = INDUSTRY_CONTENTS.get(industry)
+    display = info["display_name"] if info else "サイト"
+    joined = "、".join(missing_keywords)
+    if info:
+        return f"{display}向けに『{joined}』に関する情報を追加すると効果的です。"
+    return f"関連性の高い内容（例: {joined}）をページに盛り込むことを検討してください。"

--- a/seo_aio_streamlit.py
+++ b/seo_aio_streamlit.py
@@ -163,6 +163,7 @@ from core.industry_detector import (
 from core.aio_scorer import calculate_personalization_score
 from core.visualization import create_aio_score_chart_vertical, create_aio_radar_chart
 from core.text_utils import detect_mojibake
+from core.advice_utils import generate_actionable_advice
 
 
 def add_corner(canvas, doc_obj) -> None:
@@ -309,17 +310,20 @@ class SEOAIOAnalyzer:
                 self.seo_results, self.aio_results, seo_weight, aio_weight
             )
 
+            advice = generate_actionable_advice(missing_contents, detected_key)
+
             self.last_analysis_results = {
-                "url": url, 
+                "url": url,
                 "user_industry": user_industry,
                 "final_industry": final_industry,
                 "industry_analysis": industry_analysis,
                 "balance": balance,
-                "seo_results": self.seo_results, 
+                "seo_results": self.seo_results,
                 "aio_results": self.aio_results,
                 "integrated_results": integrated_results,
                 "industry_fit_score": industry_fit_score,
                 "missing_industry_contents": missing_contents,
+                "industry_advice": advice,
                 "timestamp": datetime.now().isoformat()
             }
             return self.last_analysis_results
@@ -1010,6 +1014,12 @@ JSON以外のテキストや説明は一切含めないでください。
         if improvements:
             bullet_items = [ListItem(Paragraph(imp, normal_style)) for imp in improvements]
             story.append(ListFlowable(bullet_items, bulletType='bullet'))
+
+        advice_txt = self.last_analysis_results.get("industry_advice", "")
+        if advice_txt:
+            story.append(Spacer(1, 2*mm))
+            story.append(Paragraph(f"<b>業界向けアドバイス:</b> {advice_txt}", normal_style))
+
         story.append(Spacer(1, 5*mm))
 
         # スコア分布グラフの追加
@@ -1502,6 +1512,11 @@ def main():
             rec_balance = integrated_results.get('recommended_balance', {})
             st.subheader("推奨分析バランス")
             st.write(f"SEO {rec_balance.get('seo_focus', 50)}% - AIO {rec_balance.get('aio_focus', 50)}%")
+
+            advice_text = results.get('industry_advice', '')
+            if advice_text:
+                st.subheader("業界向けアドバイス")
+                st.write(advice_text)
             st.markdown("</div>", unsafe_allow_html=True)
         
         with tab2:  # AIO分析

--- a/tests/test_advice_utils.py
+++ b/tests/test_advice_utils.py
@@ -1,0 +1,16 @@
+import unittest
+from core.advice_utils import generate_actionable_advice
+
+class TestActionableAdvice(unittest.TestCase):
+    def test_known_industry(self):
+        advice = generate_actionable_advice(['予約', '地図'], 'restaurant')
+        self.assertIn('飲食店', advice)
+        self.assertIn('予約、地図', advice)
+
+    def test_unknown_industry(self):
+        advice = generate_actionable_advice(['予約'], 'unknown')
+        self.assertIn('予約', advice)
+        self.assertNotIn('飲食店', advice)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- create helper `core/advice_utils.py` with `generate_actionable_advice`
- display advice in Streamlit overview and embed in PDF report
- return advice from analysis results
- add unit tests covering advice generation

## Testing
- `python -m unittest discover tests`

------
https://chatgpt.com/codex/tasks/task_e_688979c328848333b373b5dae2033eb8