### PR TITLE
Add tests for AIO scoring utilities

### DIFF
--- a/tests/test_advice_utils.py
+++ b/tests/test_advice_utils.py
@@ -12,5 +12,9 @@ class TestActionableAdvice(unittest.TestCase):
         self.assertIn('予約', advice)
         self.assertNotIn('飲食店', advice)
 
+    def test_no_missing_keywords(self):
+        advice = generate_actionable_advice([], 'restaurant')
+        self.assertIn('重要キーワードは見当たりません', advice)
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_personalization.py
+++ b/tests/test_personalization.py
@@ -24,6 +24,25 @@ class TestPersonalizationScore(unittest.TestCase):
         self.assertAlmostEqual(total, scores['業種適合性'], places=1)
         self.assertIn('地図', missing)
 
+    def test_calculate_aio_score_unknown(self):
+        if not calculate_aio_score:
+            self.skipTest("main module not available")
+        text = "これはどの業種にも当てはまらない内容です。"
+        total, scores, industry, missing = calculate_aio_score(text)
+        self.assertEqual(industry, 'unknown')
+        self.assertEqual(total, 0.0)
+        self.assertEqual(scores['業種適合性'], 0.0)
+        self.assertEqual(missing, [])
+
+    def test_calculate_aio_score_empty(self):
+        if not calculate_aio_score:
+            self.skipTest("main module not available")
+        total, scores, industry, missing = calculate_aio_score('')
+        self.assertEqual(industry, 'unknown')
+        self.assertEqual(total, 0.0)
+        self.assertEqual(scores['業種適合性'], 0.0)
+        self.assertEqual(missing, [])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -29,6 +29,7 @@ class TestVisualization(unittest.TestCase):
         fig = create_aio_radar_chart(values, labels)
         self.assertTrue(hasattr(fig, 'data'))
         self.assertEqual(len(fig.data[0]['r']), 6)
+        self.assertEqual(fig.layout.get('polar', {}).get('radialaxis', {}).get('range'), [0, 100])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- cover missing keywords case for actionable advice
- expand calculate_aio_score tests for unknown and empty text
- verify radar chart radial range

## Testing
- `python -m unittest discover tests`

------
https://chatgpt.com/codex/tasks/task_e_6889bb025e7083338e1d9a04c12ae761