### PR TITLE
Implement industry advice display

### DIFF
--- a/core/advice_utils.py
+++ b/core/advice_utils.py
@@ -13,8 +13,14 @@ def generate_actionable_advice(missing_keywords: List[str], industry: str) -> st
         return "特に不足している重要キーワードは見当たりません。"
 
     info = INDUSTRY_CONTENTS.get(industry)
-    display = info["display_name"] if info else "サイト"
     joined = "、".join(missing_keywords)
     if info:
-        return f"{display}向けに『{joined}』に関する情報を追加すると効果的です。"
-    return f"関連性の高い内容（例: {joined}）をページに盛り込むことを検討してください。"
+        display = info["display_name"]
+        return (
+            f"{display}のサイトとして、見込み客が求める『{joined}』に関する情報が不足しているようです。"
+            "これらのコンテンツを追加することで、サイトの信頼性が向上し、受注機会の増加につながります。"
+        )
+    return (
+        "サイトのコンテンツが少ないため、業種を特定できませんでした。"
+        "事業内容、サービス、会社情報などを具体的に記述し、コンテンツを充実させることを強くお勧めします。"
+    )

--- a/seo_aio_streamlit.py
+++ b/seo_aio_streamlit.py
@@ -321,6 +321,7 @@ class SEOAIOAnalyzer:
                 "seo_results": self.seo_results,
                 "aio_results": self.aio_results,
                 "integrated_results": integrated_results,
+                "detected_industry": detected_key,
                 "industry_fit_score": industry_fit_score,
                 "missing_industry_contents": missing_contents,
                 "industry_advice": advice,
@@ -1488,6 +1489,12 @@ def main():
         with tab1:  # 概要
             st.markdown("<div class='function-section'>", unsafe_allow_html=True)
             st.header("分析概要")
+
+            detected = results.get("detected_industry", "unknown")
+            industry_display_name = INDUSTRY_CONTENTS.get(detected, {}).get(
+                "display_name", "特定できませんでした"
+            )
+            st.subheader(f"判定された業種: {industry_display_name}")
             
             # スコア表示（メーター削除）
             col1, col2, col3 = st.columns(3)

--- a/tests/test_advice_utils.py
+++ b/tests/test_advice_utils.py
@@ -5,11 +5,12 @@ class TestActionableAdvice(unittest.TestCase):
     def test_known_industry(self):
         advice = generate_actionable_advice(['予約', '地図'], 'restaurant')
         self.assertIn('飲食店', advice)
-        self.assertIn('予約、地図', advice)
+        self.assertIn('予約', advice)
+        self.assertIn('地図', advice)
 
     def test_unknown_industry(self):
         advice = generate_actionable_advice(['予約'], 'unknown')
-        self.assertIn('予約', advice)
+        self.assertIn('業種を特定できませんでした', advice)
         self.assertNotIn('飲食店', advice)
 
     def test_no_missing_keywords(self):


### PR DESCRIPTION
## Summary
- display detected industry name in the Streamlit dashboard
- generate clearer actionable advice messages for missing contents
- store the detected industry key for later use
- update unit tests for new advice messages

## Testing
- `python -m unittest discover tests`

------
https://chatgpt.com/codex/tasks/task_e_6889c2a0dae88333b31e4528cd1f8375