### PR TITLE
Add test for empty industry detection

### DIFF
--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -18,5 +18,8 @@ class TestIndustryDetector(unittest.TestCase):
         industry = detect_industry(text)
         self.assertEqual(industry, "restaurant")
 
+    def test_detect_industry_empty(self):
+        self.assertEqual(detect_industry(""), "unknown")
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- expand industry detector tests to check empty text handling

## Testing
- `python -m unittest discover tests`

------
https://chatgpt.com/codex/tasks/task_e_6889d71a366883338f1fee9e758534e1