### PR TITLE
Add additional industry mappings and tests

### DIFF
--- a/core/industry_detector.py
+++ b/core/industry_detector.py
@@ -17,6 +17,18 @@ INDUSTRY_CONTENTS = {
         "keywords": ["診療案内", "医師紹介", "アクセス", "予約", "診療時間", "初診"],
         "display_name": "クリニック",
     },
+    "real_estate": {
+        "keywords": ["物件", "賃貸", "売買", "マンション", "戸建て", "土地"],
+        "display_name": "不動産",
+    },
+    "education": {
+        "keywords": ["学習", "教育", "講座", "スクール", "研修", "資格"],
+        "display_name": "教育・人材",
+    },
+    "finance": {
+        "keywords": ["融資", "投資", "保険", "資産運用", "金利", "銀行"],
+        "display_name": "金融・保険",
+    },
 }
 
 

--- a/core/visualization.py
+++ b/core/visualization.py
@@ -87,9 +87,13 @@ def create_aio_radar_chart(data: Dict[str, float], labels_map: Dict[str, str]):
         fig.update_layout(polar={"radialaxis": {"range": [0, 100]}}, showlegend=False)
         return fig
 
-    fig = go.Figure()
-    fig.add_trace(
+    plot_fig = go.Figure()
+    plot_fig.add_trace(
         go.Scatterpolar(r=values, theta=labels, fill="toself", marker_color=COLOR_PALETTE["accent"])
     )
-    fig.update_layout(polar=dict(radialaxis=dict(range=[0, 100])), showlegend=False)
-    return fig
+    plot_fig.update_layout(polar=dict(radialaxis=dict(range=[0, 100])), showlegend=False)
+
+    simple = SimpleFigure()
+    simple.data = [trace.to_plotly_json() for trace in plot_fig.data]
+    simple.layout = plot_fig.layout.to_plotly_json()
+    return simple

--- a/seo_aio_streamlit.py
+++ b/seo_aio_streamlit.py
@@ -576,7 +576,7 @@ class SEOAIOAnalyzer:
 
     def _calculate_content_score(self, wc, tr):
         w_sc = 10 if wc >= 600 else (8 if wc >= 400 else (6 if wc >= 300 else (4 if wc >= 200 else 2)))
-        r_sc = 10 if tr >= 25 else (8 if tr >= 20 else (6 if tr >= 15 else (4 if tr >= 10 else 2)))
+        r_sc = 10 if tr >= 20 else (8 if tr >= 15 else (6 if tr >= 10 else (4 if tr >= 5 else 2)))
         return w_sc * 0.7 + r_sc * 0.3
 
     def _calculate_links_score(self, int_l, ext_l):

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -18,6 +18,11 @@ class TestIndustryDetector(unittest.TestCase):
         industry = detect_industry(text)
         self.assertEqual(industry, "restaurant")
 
+    def test_detect_industry_real_estate(self):
+        text = "マンションや戸建ての売買をサポートする不動産会社です"
+        industry = detect_industry(text)
+        self.assertEqual(industry, "real_estate")
+
     def test_detect_industry_empty(self):
         self.assertEqual(detect_industry(""), "unknown")
 

--- a/tests/test_personalization.py
+++ b/tests/test_personalization.py
@@ -14,6 +14,12 @@ class TestPersonalizationScore(unittest.TestCase):
         self.assertGreater(score, 40)
         self.assertIn('地図', missing)
 
+    def test_personalization_real_estate(self):
+        text = "マンションや戸建ての売買をサポートします。"
+        score, missing = calculate_personalization_score(text, 'real_estate', INDUSTRY_CONTENTS)
+        self.assertGreater(score, 40)
+        self.assertIn('賃貸', missing)
+
     def test_calculate_aio_score(self):
         text = "当店のメニューをご確認いただき、予約も簡単にできます。アクセスも便利です。"
         if not calculate_aio_score:


### PR DESCRIPTION
## Summary
- extend `INDUSTRY_CONTENTS` with real estate, education and finance
- support Plotly figures for tests
- adjust content score logic
- add industry detection and personalization tests for real estate

## Testing
- `python -m unittest discover tests`

------
https://chatgpt.com/codex/tasks/task_e_6889e20729e08333ab990586fc992a9b