### PR TITLE
Fix radar chart figure return type

### DIFF
--- a/core/visualization.py
+++ b/core/visualization.py
@@ -89,11 +89,15 @@ def create_aio_radar_chart(data: Dict[str, float], labels_map: Dict[str, str]):
 
     plot_fig = go.Figure()
     plot_fig.add_trace(
-        go.Scatterpolar(r=values, theta=labels, fill="toself", marker_color=COLOR_PALETTE["accent"])
+        go.Scatterpolar(
+            r=values,
+            theta=labels,
+            fill="toself",
+            marker_color=COLOR_PALETTE["accent"],
+        )
     )
-    plot_fig.update_layout(polar=dict(radialaxis=dict(range=[0, 100])), showlegend=False)
+    plot_fig.update_layout(
+        polar=dict(radialaxis=dict(range=[0, 100])), showlegend=False
+    )
 
-    simple = SimpleFigure()
-    simple.data = [trace.to_plotly_json() for trace in plot_fig.data]
-    simple.layout = plot_fig.layout.to_plotly_json()
-    return simple
+    return plot_fig


### PR DESCRIPTION
## Summary
- return a proper Plotly figure from `create_aio_radar_chart`

## Testing
- `python -m unittest discover tests`

------
https://chatgpt.com/codex/tasks/task_e_688a09cb48348333935091319c9f92a1